### PR TITLE
warn more, stop less

### DIFF
--- a/tests/testthat/_snaps/set.md
+++ b/tests/testthat/_snaps/set.md
@@ -14,5 +14,5 @@
       Variable units (e.g., age in years):
       
         - number = ?
-        - integer = ?
+        - integer = ? 
 

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -54,3 +54,40 @@ test_that("each recode feature works together at the same time", code = {
 
 })
 
+test_that(
+  "recode throws warning w/explanation for duplicated labels",
+  code = {
+
+    dd <- data_dictionary(
+      nominal_variable('htn', 'hypertension', category_levels = c('no', 'yes')),
+      nominal_variable('diab', 'diabetes', category_levels = c('no', 'yes')),
+      nominal_variable('age', "age group", category_levels = c("first", "second")),
+      nominal_variable("bmi", "bmu group", category_levels = c("first", "second"))
+    ) %>%
+      set_factor_labels(htn = c(no = "Nope", 'yes' = 'hypertension'),
+                        diab = c(no = "Nope", 'yes' = 'diabetes'),
+                        age = c("first" = "50-65"),
+                        bmi = c("first" = "< 18"))
+
+    expect_warning(dd$recode(c("no", "yes", "first")),
+                   regexp = "multiple labels")
+
+    expect_equal(dd$recode("no"), "Nope")
+
+  }
+)
+
+test_that(
+  "recode is unphased by duplicated binary levels w/out diverging labels",
+  code = {
+
+    dd <- data_dictionary(
+      nominal_variable('htn', 'hypertension', category_levels = c('no', 'yes')),
+      nominal_variable('diab', 'diabetes', category_levels = c('no', 'yes'))
+    )
+
+    expect_equal(dd$recode(c("no", "yes")), c("no", "yes"))
+
+  }
+)
+


### PR DESCRIPTION
this should make the recode function less prone to throw errors about duplicates, particularly when they are not actually causing a problem